### PR TITLE
add more explicit error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ xcuserdata
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
+*.DS_Store
 
 ## Obj-C/Swift specific
 *.hmap

--- a/ListKit/ArrayDataSource.swift
+++ b/ListKit/ArrayDataSource.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-/// A `UITableViewCell` adopoting this type can be used together
+/// A `UITableViewCell` adopting this type can be used together
 /// with the `ArrayDataSource` class.
 public protocol ListKitCellProtocol {
   typealias CellType
@@ -50,24 +50,25 @@ public class ArrayDataSource<U, T where U:ListKitCellProtocol, U:UITableViewCell
   }
 
   public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-    var cell = tableView.dequeueReusableCellWithIdentifier(cellIdentifier) as! U?
+    var nullableCell = tableView.dequeueReusableCellWithIdentifier(cellIdentifier) as? U
     
-    if var cell = cell {
-      cell.model = array[indexPath.row]
-    } else {
+    if nullableCell == nil {
       if let nib = nib {
-        // if nib was registered, load from there
         tableView.registerNib(nib, forCellReuseIdentifier: cellIdentifier)
-        cell = tableView.dequeueReusableCellWithIdentifier(cellIdentifier) as? U
-        cell!.model = array[indexPath.row]
+        nullableCell = tableView.dequeueReusableCellWithIdentifier(cellIdentifier) as? U
       } else {
-        // else, create cell programatically
-        cell = U(style: .Default, reuseIdentifier: cellIdentifier)
-        cell!.model = array[indexPath.row]
+        nullableCell = U(style: .Default, reuseIdentifier: cellIdentifier)
       }
     }
     
-    return cell!
+    // This can only be invalid if `nib` specifies a cell with the wrong class and the first dequeue didn't work
+    guard var cell = nullableCell else {
+      fatalError("Unable to dequeue valid cell of type \(U.self) from reuse identifier \(cellIdentifier) or create cell of type \(U.self) from nib \(nib)")
+    }
+    
+    cell.model = array[indexPath.row]
+    
+    return cell
   }
   
 }

--- a/ListKitTests/BasicDataSourceTests.swift
+++ b/ListKitTests/BasicDataSourceTests.swift
@@ -13,7 +13,7 @@ import ListKit
 class CustomTableViewCell: UITableViewCell, ListKitCellProtocol {
   var model:AnyObject? {
     didSet {
-      self.textLabel!.text = model as! String?
+      self.textLabel!.text = model as? String
     }
   }
 }
@@ -36,7 +36,7 @@ class BasicDataSourceTests: XCTestCase {
       let source = ArrayDataSource(array: array, cellType: CustomTableViewCell.self)
       let cell = source.tableView(UITableView(), cellForRowAtIndexPath: NSIndexPath(forRow: 0, inSection: 0))
       
-      XCTAssertEqual(cell.textLabel!.text!, "Yay")
+      XCTAssertEqual(cell.textLabel!.text, "Yay")
     }
   
 }


### PR DESCRIPTION
The `fatalError()` can be avoided by manually initializing, like what's already being done

```
nullableCell = U(style: .Default, reuseIdentifier: cellIdentifier)
```

but I left it in there because I think it'd probably be a mistake to accidentally specify the wrong class in a nib.
